### PR TITLE
Throw an error instead of using process.exit().

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -14,7 +14,7 @@ async function main() {
     makeDirs(projectName);
     createFiles(projectName);
   } catch (error) {
-    throw new Error("Failed to create project: " + error.message);
+    throw new Error(`Failed to create project: ${error.message}`);
   }
 }
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -14,8 +14,7 @@ async function main() {
     makeDirs(projectName);
     createFiles(projectName);
   } catch (error) {
-    console.error(`Error: ${error.message}`);
-    process.exit(1);
+    throw new Error("Failed to create project: " + error.message);
   }
 }
 


### PR DESCRIPTION
This PR replaces `process.exit()` calls with thrown errors to address JS0263 violations. This allows for proper error handling and avoids abrupt program termination.